### PR TITLE
Update responsive-sketchpad.js

### DIFF
--- a/responsive-sketchpad.js
+++ b/responsive-sketchpad.js
@@ -341,6 +341,15 @@
     Sketchpad.prototype.setLineColor = function (color) {
         this.opts.line.color = color;
     };
+	
+/** 
+* Converts to image File 
+* @param {string} type - example 'png'
+*/
+Sketchpad.prototype.toDataURL = function(type)
+{
+	return this.canvas.toDataURL(type);
+}
 
     /**
      * Draw a line


### PR DESCRIPTION
Added image download or converting option.
Try the following function to save the drawing into a PNG image.

function save {
		var gh = pad.toDataURL('png');
		var a  = document.createElement('a');
		a.href = gh;
		a.download = 'image.png';
		document.body.appendChild(a);
		a.click()
		document.body.removeChild(a);
}